### PR TITLE
fix inner match in security types example

### DIFF
--- a/README.md
+++ b/README.md
@@ -82,7 +82,7 @@ tyrade!{
 
   fn MaxLevel<S1, S2>() {
     match S1 {
-      Low => S2,
+      Low => match S2 {
         Low => Low,
         High => High
       }


### PR DESCRIPTION
The opened and closed braces don't match in the original example, and it seems there's a missing `match` keyword.